### PR TITLE
Fixed INSTALLED_APP order to allow city-specific overrides.

### DIFF
--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -34,15 +34,15 @@ ALLOWED_HOSTS = [
 # Application definition
 
 INSTALLED_APPS = (
+    'yourcity',
+    'councilmatic_core',
+    'haystack',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'haystack',
-    'councilmatic_core',
-    'yourcity',
 )
 
 try:


### PR DESCRIPTION
See: https://stackoverflow.com/questions/31925458/importance-of-apps-orders-in-installed-apps

Resolves #2