### PR TITLE
Add info about adding a Google API key for maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,13 @@ This file is important! It's where you keep the parts of your Councilmatic that 
             <td>Yes</td>
         </tr>
         <tr>
+            <td>GOOGLE_API_KEY</td>
+            <td>
+                API key for rendering maps on council members and person detail pages. [Learn about creating your own Google API Key.](https://developers.google.com/maps/documentation/javascript/get-api-key)
+            </td>
+            <td>No</td>
+        </tr>
+        <tr>
             <td>HEADSHOT_PATH</td>
             <td>
                 Absolute path to where the data loader will save

--- a/councilmatic/settings_deployment.py.example
+++ b/councilmatic/settings_deployment.py.example
@@ -49,6 +49,9 @@ DISQUS_SHORTNAME = None
 # analytics tracking code
 ANALYTICS_TRACKING_CODE = ''
 
+# Google Maps API Key
+GOOGLE_API_KEY = ''
+
 HEADSHOT_PATH = os.path.join(os.path.dirname(__file__), '..'
                              '/chicago/static/images/')
 


### PR DESCRIPTION
Adds instructions for creating a Google Maps API, per this PR: https://github.com/datamade/django-councilmatic/pull/212