### PR TITLE
Update starter template to reflect changes in 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ python manage.py createsuperuser
 
 `django-councilmatic` leverages, and in some instances, lightly extends the Open Civic Data standard, implemented in Django as [`python-opencivicdata`](https://github.com/opencivicdata/python-opencivicdata). The next step toward running a new Councilmatic instance is to locate data about your city and use it to populate these OCD models.
 
-How you do that is up to you. At DatMade, we maintain a series of external municipal scrapers that retrieve data from Legistar-backed sites.
+How you do that is up to you. At DataMade, we maintain a series of external municipal scrapers that retrieve data from Legistar-backed sites.
 
 If your city runs a Legistar-backed site, see [`scrapers-us-municipal`](https://github.com/opencivicdata/scrapers-us-municipal) for several examples of scrapers that will populate a given database with legislative data in the format required by Councilmatic. These scrapers leverage [`python-legistar-scraper`](https://github.com/opencivicdata/python-legistar-scraper) to scrape Legistar and the [`pupa`](https://github.com/opencivicdata/pupa) framework to shape and import data.
 

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -38,9 +38,12 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'debug_toolbar',
     'haystack',
-    'city',
+    'chicago',
     'councilmatic_core',
+    'opencivicdata.core',
+    'opencivicdata.legislative',
 )
 
 try:
@@ -48,7 +51,7 @@ try:
 except NameError:
     pass
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -102,6 +105,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-
+STATIC_PATH = os.path.join(os.path.dirname(__file__), '..', APP_NAME, 'static')
 
 HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'debug_toolbar',
     'haystack',
-    'chicago',
+    'city',
     'councilmatic_core',
     'opencivicdata.core',
     'opencivicdata.legislative',

--- a/councilmatic/settings_deployment.py.example
+++ b/councilmatic/settings_deployment.py.example
@@ -14,7 +14,7 @@ DEBUG = False
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
         'NAME': 'chi_councilmatic',
         'USER': '',
         'PASSWORD': '',
@@ -51,8 +51,5 @@ ANALYTICS_TRACKING_CODE = ''
 
 # Google Maps API Key
 GOOGLE_API_KEY = ''
-
-HEADSHOT_PATH = os.path.join(os.path.dirname(__file__), '..'
-                             '/chicago/static/images/')
 
 EXTRA_APPS = ()

--- a/councilmatic/settings_jurisdiction.py
+++ b/councilmatic/settings_jurisdiction.py
@@ -4,10 +4,10 @@
 # These settings are required #
 ###############################
 
-OCD_JURISDICTION_ID = 'ocd-jurisdiction/country:us/state:il/place:chicago/government'
-OCD_CITY_COUNCIL_ID = 'ocd-organization/ef168607-9135-4177-ad8e-c1f7a4806c3a'
+OCD_CITY_COUNCIL_NAME = 'Chicago City Council'
 CITY_COUNCIL_NAME = 'Chicago City Council'
-LEGISLATIVE_SESSIONS = ['2007', '2011', '2015'] # the last one in this list should be the current legislative session
+OCD_JURISDICTION_IDS = ['ocd-jurisdiction/country:us/state:il/place:chicago/government']
+LEGISLATIVE_SESSIONS = ['2007', '2011', '2015', '2019'] # the last one in this list should be the current legislative session
 CITY_NAME = 'Chicago'
 CITY_NAME_SHORT = 'Chicago'
 
@@ -68,16 +68,11 @@ FOOTER_CREDITS = [
 # this is the default text in search bars
 SEARCH_PLACEHOLDER_TEXT = '' # e.g. 'police, zoning, O2015-7825, etc.'
 
-
-
 # these should live in APP_NAME/static/
 IMAGES = {
     'favicon': 'images/favicon.ico',
     'logo': 'images/logo.png',
 }
-
-
-
 
 # THE FOLLOWING ARE VOCAB SETTINGS RELEVANT TO DATA MODELS, LOGIC
 # (this is diff from VOCAB above, which is all for the front end)
@@ -94,8 +89,6 @@ COMMITTEE_CHAIR_TITLE = 'Chairman'
 # this is the anme of the role of committee members,
 # as stored in legistar
 COMMITTEE_MEMBER_TITLE = 'Member'
-
-
 
 
 # this is for convenience, & used to populate a table
@@ -140,3 +133,6 @@ MANUAL_HEADSHOTS = {
 EXTRA_TITLES = {
     # e.g. 'emanuel-rahm': 'Mayor',
 }
+
+# whether the app is using django-councilmatic-notifications
+USING_NOTIFICATIONS = False

--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -30,7 +30,7 @@ sqs = SearchQuerySet().facet('bill_type')\
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^search/', CouncilmaticFacetedSearchView(searchqueryset=sqs, 
-                                       form_class=CouncilmaticSearchForm)),
+    url(r'^search/', CouncilmaticFacetedSearchView(searchqueryset=sqs,
+                                                   form_class=CouncilmaticSearchForm)),
     url(r'', include('councilmatic_core.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 psycopg2==2.6.2
-django-councilmatic<0.7
+https://github.com/datamade/django-councilmatic/archive/ocd.zip


### PR DESCRIPTION
This PR updates the documentation to reflect changes in the 1.0 `django-councilmatic` release. Substantive changes include:

- Add stronger guidance on populating the database
- Add light documentation for containerizing Solr
- Remove references to the OCD API
- Reference Haystack

Questions:

1. Should I add a blurb on proxy models? If so, I'm inclined to copy/paste the `Approach` section (with light edits) from this comment: https://github.com/datamade/django-councilmatic/pull/240#issuecomment-503221198